### PR TITLE
bring back --fmad option to nvcc_wrapper

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -229,7 +229,7 @@ do
     fi
     ;;
   #Handle known nvcc args
-  --dryrun|-dryrun|--verbose|--keep|-keep|--source-in-ptx|-src-in-ptx|--keep-dir*|-keep-dir*|-G|-lineinfo|--generate-line-info|-extended-lambda|-expt-extended-lambda|-expt-relaxed-constexpr|--resource-usage|-res-usage|-fmad=*|--use_fast_math|-use_fast_math|--Wext-lambda-captures-this|-Wext-lambda-captures-this)
+  --dryrun|-dryrun|--verbose|--keep|-keep|--source-in-ptx|-src-in-ptx|--keep-dir*|-keep-dir*|-G|-lineinfo|--generate-line-info|-extended-lambda|-expt-extended-lambda|-expt-relaxed-constexpr|--resource-usage|-res-usage|--fmad=*|--use_fast_math|-use_fast_math|--Wext-lambda-captures-this|-Wext-lambda-captures-this)
     cuda_args="$cuda_args $1"
     ;;
   #Handle more known nvcc args


### PR DESCRIPTION
the --fmad option captured by nvcc_wrapper somehow lost one "-" between Kokkos 4.2 and Kokkos 4.3. This PR brings it back.